### PR TITLE
Add latest yarn 3 to packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc"
   },
+  "packageManager": "yarn@3.4.1",
   "dependencies": {
     "@docusaurus/core": "latest",
     "@docusaurus/preset-classic": "latest",


### PR DESCRIPTION
If you add a package manager to the `packageManager` field, [corepack](https://nodejs.org/api/corepack.html) will download and use that package manager automatically.