### PR TITLE
update baseurl to / to reflect new dev.kidsoncomputers.org domain

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const config = {
     title: 'Kids on Computers',
     tagline: 'Bringing technology to underprivileged kids worldwide',
     url: 'https://kidsoncomputers.github.io',
-    baseUrl: '/website/',
+    baseUrl: '/',
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon.ico',


### PR DESCRIPTION
Since we've set up a custom domain we have to change the baseurl configuration. We'll now use `dev.kidsoncomputers.org` instead of the github pages url