### PR TITLE
Add Ouaouizerth Lab Page with Details from Old Website

### DIFF
--- a/labs/morocco/_category_.json
+++ b/labs/morocco/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Morocco",
     "link": {
-        "type": "generated-index",
+        "type": "generated-index"
     }
 }

--- a/labs/morocco/ouledmoussa.md
+++ b/labs/morocco/ouledmoussa.md
@@ -1,0 +1,7 @@
+---
+title: Ouled Moussa
+---
+
+# Ouled Moussa
+
+

--- a/labs/morocco/zfoumjamaa.md
+++ b/labs/morocco/zfoumjamaa.md
@@ -1,0 +1,6 @@
+---
+title: Foum Jamaa
+---
+
+# Foum Jamaa
+


### PR DESCRIPTION
This PR adds a dedicated page for the Ouaouizerth lab under the Morocco section, using the information and images from the old website.

**Issues GitHub Link**: [https://github.com/kidsoncomputers/website/issues/15](https://github.com/kidsoncomputers/website/issues/15)


![Screenshot from 2025-04-05 13-06-30](https://github.com/user-attachments/assets/2493c294-7385-4b5a-946a-e4e0884ee70d)
